### PR TITLE
feat: surface missing privileged intents in UI

### DIFF
--- a/src/components/discord/intent-warning.tsx
+++ b/src/components/discord/intent-warning.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { ExternalLink, ShieldAlert } from "lucide-react";
+import Link from "next/link";
+import { useRealtimeStore } from "@/lib/store";
+import { INTENTS } from "@/lib/discord/constants";
+import { cn } from "@/lib/utils";
+
+export function getMissingPrivilegedIntents(active: number) {
+  const missing: { key: "members" | "presence" | "content"; label: string }[] = [];
+  if (!(active & INTENTS.GUILD_MEMBERS))
+    missing.push({ key: "members", label: "Server Members" });
+  if (!(active & INTENTS.GUILD_PRESENCES))
+    missing.push({ key: "presence", label: "Presence" });
+  if (!(active & INTENTS.MESSAGE_CONTENT))
+    missing.push({ key: "content", label: "Message Content" });
+  return missing;
+}
+
+export function devPortalUrl(appId: string | undefined) {
+  return appId
+    ? `https://discord.com/developers/applications/${appId}/bot`
+    : "https://discord.com/developers/applications";
+}
+
+interface BannerProps {
+  reason: "content" | "members" | "presence";
+  className?: string;
+}
+
+export function IntentBanner({ reason, className }: BannerProps) {
+  const intents = useRealtimeStore((s) => s.activeIntents);
+  const state = useRealtimeStore((s) => s.gatewayState);
+  const appId = useRealtimeStore((s) => s.user?.id);
+
+  const flag =
+    reason === "content"
+      ? INTENTS.MESSAGE_CONTENT
+      : reason === "members"
+        ? INTENTS.GUILD_MEMBERS
+        : INTENTS.GUILD_PRESENCES;
+
+  if (state !== "ready") return null;
+  if (intents & flag) return null;
+
+  const text =
+    reason === "content"
+      ? "Message Content Intent is disabled. Messages from other users will appear empty until you enable it in the Discord Developer Portal."
+      : reason === "members"
+        ? "Server Members Intent is disabled. The full member list cannot be loaded until you enable it in the Discord Developer Portal."
+        : "Presence Intent is disabled. Online status will not appear until you enable it in the Discord Developer Portal.";
+
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 px-3 py-2 text-xs border-b bg-yellow-500/10 text-yellow-700 dark:text-yellow-400 border-yellow-500/30",
+        className,
+      )}
+    >
+      <ShieldAlert className="size-4 shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">{text}</div>
+      <Link
+        href={devPortalUrl(appId)}
+        target="_blank"
+        className="inline-flex items-center gap-1 font-medium underline-offset-2 hover:underline shrink-0"
+      >
+        Open Dev Portal
+        <ExternalLink className="size-3" />
+      </Link>
+    </div>
+  );
+}

--- a/src/components/discord/member-list.tsx
+++ b/src/components/discord/member-list.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { DiscordAvatar } from "@/components/ui/discord-avatar";
 import { avatarUrl } from "@/lib/discord/cdn";
 import { UserProfilePopover } from "@/components/discord/user-profile-popover";
+import { IntentBanner } from "@/components/discord/intent-warning";
 import { getGuildMembers } from "@/api/data/actions";
 import { INTENTS } from "@/lib/discord/constants";
 import type { GuildMember, Presence, Role } from "@/lib/discord/types";
@@ -162,6 +163,7 @@ export function MemberList({ guildId }: Props) {
           className="h-8 text-xs"
         />
       </div>
+      <IntentBanner reason="members" />
       <div ref={scrollRef} onScroll={onScroll} className="flex-1 overflow-y-auto p-2">
         {!hasMembersIntent && members.length === 0 && (
           <p className="text-xs text-muted-foreground p-2">

--- a/src/components/discord/message-list.tsx
+++ b/src/components/discord/message-list.tsx
@@ -45,6 +45,7 @@ import {
 import { MessageItem } from "@/components/discord/message";
 import { MessageContent } from "@/components/discord/message-content";
 import { UserProfilePopover } from "@/components/discord/user-profile-popover";
+import { IntentBanner } from "@/components/discord/intent-warning";
 import { useRealtimeStore } from "@/lib/store";
 import type { GuildMember, Message } from "@/lib/discord/types";
 import type { ReplyTarget } from "@/components/discord/message-input";
@@ -389,6 +390,7 @@ export function MessageList({ channelId, serverId, postStarterId, onReply }: Pro
 
   return (
     <div className="relative flex-1 min-h-0 flex flex-col">
+      <IntentBanner reason="content" />
       <div
         ref={scrollRef}
         onScroll={onScroll}

--- a/src/components/discord/status-bar.tsx
+++ b/src/components/discord/status-bar.tsx
@@ -1,19 +1,21 @@
 "use client";
 
-import { Activity, Wifi, WifiOff, Loader2 } from "lucide-react";
+import { Activity, ExternalLink, Loader2, ShieldAlert, Wifi, WifiOff } from "lucide-react";
+import Link from "next/link";
 import { useRealtimeStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { INTENTS } from "@/lib/discord/constants";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { devPortalUrl, getMissingPrivilegedIntents } from "@/components/discord/intent-warning";
 
 export function StatusBar() {
   const state = useRealtimeStore((s) => s.gatewayState);
   const ping = useRealtimeStore((s) => s.pingMs);
   const rest = useRealtimeStore((s) => s.restPingMs);
   const intents = useRealtimeStore((s) => s.activeIntents);
-  const degraded =
-    state === "ready" &&
-    !((intents & INTENTS.GUILD_MEMBERS) && (intents & INTENTS.GUILD_PRESENCES) && (intents & INTENTS.MESSAGE_CONTENT));
+  const appId = useRealtimeStore((s) => s.user?.id);
+
+  const missing = state === "ready" ? getMissingPrivilegedIntents(intents) : [];
+  const degraded = missing.length > 0;
 
   const dot =
     state === "ready"
@@ -48,9 +50,12 @@ export function StatusBar() {
   const Icon = state === "ready" ? Wifi : state === "disconnected" ? WifiOff : Loader2;
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="hidden sm:flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] font-mono px-2 py-1 rounded-md hover:bg-muted/50 cursor-default transition-colors">
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className="hidden sm:flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] font-mono px-2 py-1 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"
+          aria-label="Connection details"
+        >
           <span className={cn("size-1.5 rounded-full", dot, state !== "ready" && "animate-pulse")} />
           <Icon
             className={cn(
@@ -62,10 +67,14 @@ export function StatusBar() {
           {state === "ready" && (
             <span className="text-muted-foreground/70">· {ping || "—"}ms</span>
           )}
-        </div>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        <div className="text-xs space-y-1 min-w-32">
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        className="w-80 p-0 overflow-hidden"
+      >
+        <div className="px-3 py-2.5 space-y-2 text-xs">
           <div className="flex items-center justify-between gap-3">
             <span className="text-muted-foreground">Gateway</span>
             <span className="font-mono">{ping || "—"}ms</span>
@@ -74,17 +83,38 @@ export function StatusBar() {
             <span className="text-muted-foreground">REST</span>
             <span className="font-mono">{rest || "—"}ms</span>
           </div>
-          <div className="border-t border-border/50 pt-1 flex items-center gap-1">
-            <Activity className="size-3" />
-            <span>{label}</span>
+          <div className="border-t border-border/50 pt-2 flex items-center gap-1.5">
+            <Activity className="size-3.5" />
+            <span className="font-medium">{label}</span>
           </div>
-          {degraded && (
-            <div className="text-[10px] text-yellow-600 dark:text-yellow-500">
-              Privileged intents disabled — enable in Dev Portal for member list, presence, message content.
-            </div>
-          )}
         </div>
-      </TooltipContent>
-    </Tooltip>
+        {degraded && (
+          <div className="border-t bg-yellow-500/10 px-3 py-2.5 text-xs text-yellow-700 dark:text-yellow-400 space-y-2">
+            <div className="flex items-start gap-1.5">
+              <ShieldAlert className="size-3.5 shrink-0 mt-0.5" />
+              <div className="font-medium leading-snug">
+                Privileged intents disabled
+              </div>
+            </div>
+            <ul className="pl-5 space-y-0.5 list-disc marker:text-yellow-600/70">
+              {missing.map((m) => (
+                <li key={m.key}>{m.label}</li>
+              ))}
+            </ul>
+            <p className="text-yellow-700/90 dark:text-yellow-400/80 leading-snug">
+              Enable these in the Developer Portal so the bot can read message content, members, and presence.
+            </p>
+            <Link
+              href={devPortalUrl(appId)}
+              target="_blank"
+              className="inline-flex items-center gap-1 font-medium underline-offset-2 hover:underline"
+            >
+              Open Dev Portal
+              <ExternalLink className="size-3" />
+            </Link>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
## Summary
- Convert the `StatusBar` connection tooltip into a popover so the privileged-intents warning has room to breathe and can list each missing intent (Server Members / Presence / Message Content) plus a clickable Open Dev Portal link.
- Add a reusable `IntentBanner` component and render it above `MessageList` (Message Content) and inside `MemberList` (Server Members) so users immediately understand why message bodies are empty or the member list is sparse.
- Centralise the missing-intent logic in `src/components/discord/intent-warning.tsx` (`getMissingPrivilegedIntents`, `devPortalUrl`).

## Why
Without the Message Content Intent the bot still gets messages back, but with empty `content`, which looked like a broken loader. The previous warning only existed inside a tooltip on the status pill, so users had no idea what was wrong. The banner now appears exactly where the symptom shows up, and the popover gives a one-click path to fix it in the Discord Developer Portal.

## Test plan
- [ ] Connect a bot with all privileged intents enabled: status pill stays green, no banners.
- [ ] Connect a bot with Message Content Intent disabled: yellow banner above the message list, popover lists "Message Content", Open Dev Portal link points to `/applications/<bot id>/bot`.
- [ ] Connect a bot with Server Members Intent disabled: yellow banner inside the member list panel, popover lists "Server Members".
- [ ] Connect a bot with Presence Intent disabled: popover lists "Presence", no banner (presence is not anchored to a single panel).
- [ ] Once intents are toggled on in the Dev Portal and the gateway re-identifies, all banners disappear automatically.